### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/berrysauce/minbin/security/code-scanning/1](https://github.com/berrysauce/minbin/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. In this case, the workflow only needs to read the repository contents to check out code and run analysis, so `contents: read` is sufficient. The best way to implement this is to add the following block at the root level of the workflow file (above `jobs:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
